### PR TITLE
opencensus library version updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,17 +157,20 @@ except socket.timeout:
 
 ### Tracing messages
 
+This middleware uses [opencensus](https://github.com/census-instrumentation/opencensus-python) as instrumentation library. Latest versions of opencensus released separate packages to integrate with different frameworks and tracing collector tools. When interacting with services implemented with either the C++ or Python of is-wire, we recommend to use [Zipkin](https://zipkin.apache.org/) to collect the tracing data. To do so, use the latest version of [OpenCensus Zipkin Exporter](https://github.com/census-instrumentation/opencensus-python/tree/master/contrib/opencensus-ext-zipkin).
+
 Instantiate an Exporter to trace requests:
 
 ```python
-from is_wire.core import ZipkinExporter, BackgroundThreadTransport
+from is_wire.core import AsyncTransport
+from opencensus.ext.zipkin.trace_exporter import ZipkinExporter
 
 # Create an exporter, change values accordingly to match your zipkin server
 exporter = ZipkinExporter(
     service_name="MyService",
     host_name="localhost",
     port=9411,
-    transport=BackgroundThreadTransport,
+    transport=AsyncTransport,
 )
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         'amqp==2.3.2',
         'enum34==1.1.6',
         'protobuf==3.6.0',
-        'is-opencensus>=0.1.5.3',
+        'opencensus==0.5.0',
         'prometheus-client==0.3.1',
     ]
     # change 'is-opencensus' to 'opencensus' when pull request accepted

--- a/src/is_wire/core/__init__.py
+++ b/src/is_wire/core/__init__.py
@@ -6,9 +6,7 @@ from is_wire.core.utils import now, new_uuid
 from is_wire.core.wire.status import Status, StatusCode
 from is_wire.core.wire.content_type import ContentType
 from is_wire.core.tracing.tracer import Tracer
-from opencensus.trace.exporters.zipkin_exporter import ZipkinExporter
-from opencensus.trace.exporters.transports.background_thread import \
-                                                     BackgroundThreadTransport
+from opencensus.common.transports.async_ import AsyncTransport
 
 __all__ = [
     "Channel",
@@ -21,6 +19,5 @@ __all__ = [
     "StatusCode",
     "ContentType",
     "Tracer",
-    "ZipkinExporter",
-    "BackgroundThreadTransport",
+    "AsyncTransport",
 ]

--- a/src/is_wire/core/tracing/tracer.py
+++ b/src/is_wire/core/tracing/tracer.py
@@ -1,18 +1,21 @@
 from opencensus.trace import tracer
-from ..utils import new_uuid
 from opencensus.trace.span_context import SpanContext
 
-# Patch opencensus to allow 64 bit trace ids
+# Patch opencensus to allow 64 bit trace ids.
 import opencensus.trace.span_context
 import re
 opencensus.trace.span_context.TRACE_ID_PATTERN = re.compile('[0-9a-f]{16}?')
 opencensus.trace.span_context._INVALID_TRACE_ID = '0' * 16
+# Function 'generate_trace_id' is overwritted with 'generate_span_id'
+# because this function generates a ID with 64 bits.
+opencensus.trace.span_context.generate_trace_id = \
+    opencensus.trace.span_context.generate_span_id
 
 
 class Tracer(object):
     def __init__(self, exporter=None, span_context=None):
         if span_context is None:
-            span_context = SpanContext(trace_id=format(new_uuid(), '016x'))
+            span_context = SpanContext()
 
         self.tracer = tracer.Tracer(
             exporter=exporter,


### PR DESCRIPTION
Due to the recent updated on opencensus library with some issues solved, was possible to remove the dependency of `is-opencensus` that had these issues covered.